### PR TITLE
update redcarpet dependency

### DIFF
--- a/downr.gemspec
+++ b/downr.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails', '>= 3.1.0'
   spec.add_dependency "rails_emoji", "~> 1.7.1"
   spec.add_dependency "pygmentize", "~>0.0.3" 
-  spec.add_dependency "redcarpet", "~>3.1.1"
+  spec.add_dependency "redcarpet", "~>3.2.3"
   spec.add_dependency "html-pipeline", "~> 1.9.0"
   spec.add_dependency "sanitize", "~> 3.0.0"
 end

--- a/downr.gemspec
+++ b/downr.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails', '>= 3.1.0'
   spec.add_dependency "rails_emoji", "~> 1.7.1"
   spec.add_dependency "pygmentize", "~>0.0.3" 
-  spec.add_dependency "redcarpet", "~>3.2.3"
+  spec.add_dependency "redcarpet", "~>3.4.0"
   spec.add_dependency "html-pipeline", "~> 1.9.0"
   spec.add_dependency "sanitize", "~> 3.0.0"
 end

--- a/lib/downr/version.rb
+++ b/lib/downr/version.rb
@@ -1,4 +1,4 @@
 # Gem Version
 module Downr
-  VERSION = "0.0.6"
+  VERSION = "0.0.6.1"
 end


### PR DESCRIPTION
# Problem

* `redcarpet < 3.2.3` has 1 known vulnerability: [OSVDB-120415](https://hakiri.io/technologies/redcarpet/issues/63a27fac1099ee)

# Solution

* update dependent version